### PR TITLE
Fix `path` in `cores`

### DIFF
--- a/aiogram_i18n/cores/base.py
+++ b/aiogram_i18n/cores/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, cast
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union, cast
 
 from aiogram_i18n import I18nContext
 from aiogram_i18n.exceptions import (
@@ -19,9 +19,11 @@ class BaseCore(Generic[Translator], ABC):
 
     def __init__(
         self,
+        path: Union[str, Path],
         default_locale: Optional[str] = None,
         locales_map: Optional[Dict[str, str]] = None,
     ) -> None:
+        self.path = path if isinstance(path, Path) else Path(path)
         self.default_locale = default_locale
         self.locales = {}
         self.locales_map = locales_map or {}
@@ -54,7 +56,7 @@ class BaseCore(Generic[Translator], ABC):
         locales: List[str] = []
 
         for file_path in path.iterdir():
-            if path.joinpath(file_path).is_dir():
+            if file_path.is_dir():
                 locales.append(file_path.name)
 
         if not locales:

--- a/aiogram_i18n/cores/base.py
+++ b/aiogram_i18n/cores/base.py
@@ -48,8 +48,8 @@ class BaseCore(Generic[Translator], ABC):
 
     @staticmethod
     def _extract_locales(path: Path) -> List[str]:
-        if "{locale}" in path.as_posix():
-            path = Path(path.as_posix().split("{locale}")[0])
+        if "{locale}" in path.parts:
+            path = Path(*path.parts[: path.parts.index("{locale}")])
 
         locales: List[str] = []
 

--- a/aiogram_i18n/cores/fluent_compile_core.py
+++ b/aiogram_i18n/cores/fluent_compile_core.py
@@ -26,7 +26,11 @@ class FluentCompileCore(BaseCore[FluentBundle]):
         fix_number: bool = False,
     ) -> None:
         super().__init__(default_locale=default_locale, locales_map=locales_map)
-        self.path = path if isinstance(path, Path) else Path(path)
+        self.path = (
+            path.absolute()
+            if isinstance(path, Path) and not path.is_absolute()
+            else Path(path).absolute()
+        )
         self.use_isolating = use_isolating
         self.functions = functions or {}
         if use_td:

--- a/aiogram_i18n/cores/fluent_compile_core.py
+++ b/aiogram_i18n/cores/fluent_compile_core.py
@@ -25,12 +25,7 @@ class FluentCompileCore(BaseCore[FluentBundle]):
         locales_map: Optional[Dict[str, str]] = None,
         fix_number: bool = False,
     ) -> None:
-        super().__init__(default_locale=default_locale, locales_map=locales_map)
-        self.path = (
-            path.absolute()
-            if isinstance(path, Path) and not path.is_absolute()
-            else Path(path).absolute()
-        )
+        super().__init__(path=path, default_locale=default_locale, locales_map=locales_map)
         self.use_isolating = use_isolating
         self.functions = functions or {}
         if use_td:

--- a/aiogram_i18n/cores/fluent_runtime_core.py
+++ b/aiogram_i18n/cores/fluent_runtime_core.py
@@ -27,7 +27,11 @@ class FluentRuntimeCore(BaseCore[FluentBundle]):
         fix_number: bool = False,
     ) -> None:
         super().__init__(default_locale=default_locale, locales_map=locales_map)
-        self.path = path if isinstance(path, Path) else Path(path)
+        self.path = (
+            path.absolute()
+            if isinstance(path, Path) and not path.is_absolute()
+            else Path(path).absolute()
+        )
         self.use_isolating = use_isolating
         self.functions = functions or {}
         if use_td:

--- a/aiogram_i18n/cores/fluent_runtime_core.py
+++ b/aiogram_i18n/cores/fluent_runtime_core.py
@@ -26,12 +26,7 @@ class FluentRuntimeCore(BaseCore[FluentBundle]):
         locales_map: Optional[Dict[str, str]] = None,
         fix_number: bool = False,
     ) -> None:
-        super().__init__(default_locale=default_locale, locales_map=locales_map)
-        self.path = (
-            path.absolute()
-            if isinstance(path, Path) and not path.is_absolute()
-            else Path(path).absolute()
-        )
+        super().__init__(path=path, default_locale=default_locale, locales_map=locales_map)
         self.use_isolating = use_isolating
         self.functions = functions or {}
         if use_td:

--- a/aiogram_i18n/cores/gnu_text_core.py
+++ b/aiogram_i18n/cores/gnu_text_core.py
@@ -23,12 +23,7 @@ class GNUTextCore(BaseCore[GNUTranslations]):
         raise_key_error: bool = False,
         locales_map: Optional[Dict[str, str]] = None,
     ) -> None:
-        super().__init__(default_locale=default_locale, locales_map=locales_map)
-        self.path = (
-            path.absolute()
-            if isinstance(path, Path) and not path.is_absolute()
-            else Path(path).absolute()
-        )
+        super().__init__(path=path, default_locale=default_locale, locales_map=locales_map)
         self.raise_key_error = raise_key_error
 
     def find_locales(self) -> Dict[str, GNUTranslations]:

--- a/aiogram_i18n/cores/gnu_text_core.py
+++ b/aiogram_i18n/cores/gnu_text_core.py
@@ -24,7 +24,11 @@ class GNUTextCore(BaseCore[GNUTranslations]):
         locales_map: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__(default_locale=default_locale, locales_map=locales_map)
-        self.path = path if isinstance(path, Path) else Path(path)
+        self.path = (
+            path.absolute()
+            if isinstance(path, Path) and not path.is_absolute()
+            else Path(path).absolute()
+        )
         self.raise_key_error = raise_key_error
 
     def find_locales(self) -> Dict[str, GNUTranslations]:


### PR DESCRIPTION
If `path` is not absolute - `_extract_locales()` will not find locales in folder, because `os.listdir()` / `path.iterdir()` yields dirs/files with parents.

✅ Fixed